### PR TITLE
font path error fix

### DIFF
--- a/nimx/font.nim
+++ b/nimx/font.nim
@@ -205,7 +205,7 @@ const fontSearchPaths = when defined(macosx):
         ]
     elif defined(windows):
         [
-            r"\Windows\Fonts"
+            r"c:\Windows\Fonts" #todo: system will not always in the c disk
         ]
     else:
         [


### PR DESCRIPTION
on windows 10
Hint: [Link]
Hint: operation successful (46607 lines compiled; 1.846 sec total; 51.522MB; Debug Build) [SuccessX]
Shader compile log: WARNING: 0:1: '' : #version directive missing

Shader compile log: WARNING: 0:6: '' : #version directive missing

Shader compile log: WARNING: 0:1: '' : #version directive missing

Shader compile log: WARNING: 0:6: '' : #version directive missing

Tried font '\Windows\Fonts\Arial.ttf' with no luck
WARNING: Could not create system font
Error: execution of an external program failed