### PR TITLE
Animation runner pause

### DIFF
--- a/nimx/animation_runner.nim
+++ b/nimx/animation_runner.nim
@@ -5,20 +5,46 @@ type AnimationRunner* = ref object
     animations*: seq[Animation]
     onAnimationAdded*: proc()
     onAnimationRemoved*: proc()
+    paused: bool
 
 proc newAnimationRunner*(): AnimationRunner=
     result = new(AnimationRunner)
     result.animations = @[]
+    result.paused = false
 
 proc pushAnimation*(ar: AnimationRunner, a: Animation) =
     doAssert( not a.isNil(), "Animation is nil")
 
     a.prepare(epochTime())
 
+    if ar.paused:
+        a.pause()
+
     if not (a in ar.animations):
         ar.animations.add(a)
         if not ar.onAnimationAdded.isNil():
             ar.onAnimationAdded()
+
+proc pauseAnimations*(ar: AnimationRunner, isHard: bool = false)=
+    var index = 0
+    let animLen = ar.animations.len
+
+    while index < animLen:
+        var anim = ar.animations[index]
+        anim.pause()
+
+    if isHard:
+        ar.paused = true
+
+proc resumeAnimations*(ar: AnimationRunner) =
+    var index = 0
+    let animLen = ar.animations.len
+
+    while index < animLen:
+        var anim = ar.animations[index]
+        anim.resume()
+
+    ar.paused = false
 
 proc removeAnimation*(ar: AnimationRunner, a: Animation) =
     for idx, anim in ar.animations:
@@ -29,6 +55,7 @@ proc removeAnimation*(ar: AnimationRunner, a: Animation) =
             break
 
 proc update*(ar: AnimationRunner)=
+
     var index = 0
     let animLen = ar.animations.len
 
@@ -39,7 +66,7 @@ proc update*(ar: AnimationRunner)=
         inc index
 
     index = 0
-    while index < ar.animations.len:
+    while index < animLen:
         var anim = ar.animations[index]
         if anim.finished:
             ar.animations.delete(index)

--- a/nimx/animation_runner.nim
+++ b/nimx/animation_runner.nim
@@ -66,7 +66,7 @@ proc update*(ar: AnimationRunner)=
         inc index
 
     index = 0
-    while index < animLen:
+    while index < ar.animations.len:
         var anim = ar.animations[index]
         if anim.finished:
             ar.animations.delete(index)

--- a/nimx/sdl_perform_on_main_thread.nim
+++ b/nimx/sdl_perform_on_main_thread.nim
@@ -1,10 +1,10 @@
 import sdl2
 
 {.push stack_trace:off.}
-proc performOnMainThread*(fun: proc(data: pointer) {.cdecl.}, data: pointer) =
+proc performOnMainThread*(fun: proc(data: pointer) {.cdecl.}, data: pointer): int {.discardable.} =
     var evt: UserEventObj
     evt.kind = UserEvent5
     evt.data1 = fun
     evt.data2 = data
-    discard pushEvent(cast[ptr Event](addr evt))
+    result = pushEvent(cast[ptr Event](addr evt))
 {.pop.}


### PR DESCRIPTION
add pause to animation runners
fix sdl timers when next timer fires before previous done. For example:
    var lockTime = epochTime()
    for i in 0..999989: discard

    setInterval epochTime() - lockTime, proc()=
        for i in 0..999999: discard
        echo "locked"