### PR TITLE
Added extra font directories

### DIFF
--- a/nimx/font.nim
+++ b/nimx/font.nim
@@ -202,7 +202,9 @@ when not defined(js):
                 "/usr/share/fonts/truetype",
                 "/usr/share/fonts/truetype/ubuntu-font-family",
                 "/usr/share/fonts/TTF",
-                "/usr/share/fonts/truetype/dejavu"
+                "/usr/share/fonts/truetype/dejavu",
+                "/usr/share/fonts/dejavu",
+                "/usr/share/fonts"
             ]
 
 when not defined(js):


### PR DESCRIPTION
I am running on Fedora and my truetype directory is empty except for the font's I've put in a custom directory there. The `dejavu` directory is instead located at `/usr/share/fonts/dejavu`. This PR adds `/usr/share/fonts/dejavu` and just `/usr/share/fonts` to the font search path.