### PR TITLE
Minor compatibility fixes for Nim 0.17.2

### DIFF
--- a/nimx/serializers.nim
+++ b/nimx/serializers.nim
@@ -246,8 +246,14 @@ proc pushJsonNode(s: JsonDeserializer) =
 method deserialize(s: JsonDeserializer, v: var bool) = v = s.deserializeJsonNode().bval
 method deserialize(s: JsonDeserializer, v: var int32) = v = int32(s.deserializeJsonNode().num)
 method deserialize(s: JsonDeserializer, v: var int64) = v = int64(s.deserializeJsonNode().num)
-method deserialize(s: JsonDeserializer, v: var float32) = v = s.deserializeJsonNode().getFloat()
-method deserialize(s: JsonDeserializer, v: var float64) = v = s.deserializeJsonNode().getFloat()
+
+when NimVersion <= "0.17.2":
+  method deserialize(s: JsonDeserializer, v: var float32) = v = s.deserializeJsonNode().getFNum()
+  method deserialize(s: JsonDeserializer, v: var float64) = v = s.deserializeJsonNode().getFNum()
+else:
+  method deserialize(s: JsonDeserializer, v: var float32) = v = s.deserializeJsonNode().getFloat()
+  method deserialize(s: JsonDeserializer, v: var float64) = v = s.deserializeJsonNode().getFloat()
+
 method deserialize(s: JsonDeserializer, v: var string) =
     let n = s.deserializeJsonNode()
     if n.kind == JString:

--- a/test/sample09_docking_tabs.nim
+++ b/test/sample09_docking_tabs.nim
@@ -10,7 +10,7 @@ proc newTabTitle(v: DockingTabsSampleView): string =
     inc v.tabNameIndex
     result = "Tab " & $v.tabNameIndex
 
-proc newRandomColor(): Color = newColor(rand(1.0), rand(1.0), rand(1.0), 1.0)
+proc newRandomColor(): Color = newColor(random(1.0), random(1.0), random(1.0), 1.0)
 
 proc newTab(v: DockingTabsSampleView): View =
     result = View.new(newRect(0, 0, 100, 100))

--- a/test/sample11_expanded_views.nim
+++ b/test/sample11_expanded_views.nim
@@ -12,13 +12,13 @@ method init(v: ExpandingSampleView, r: Rect) =
     v.addSubview(stackView)
 
     for i in 0..4:
-        let rand_y = rand(100 .. 400)
+        let rand_y = random(100 .. 400)
         let expView = newExpandingView(newRect(0, 0, 300, rand_y.Coord), true)
         expView.title = "newExpandedView " & $i
         stackView.addSubview(expView)
 
         for i in 0..4:
-            let rand_y = rand(0 .. 300)
+            let rand_y = random(0 .. 300)
             let expView1 = newExpandingView(newRect(0, 0, 300, 10), true)
             expView1.title = "WOW " & $i
             expView.addContent(expView1)


### PR DESCRIPTION
I took an interest in nimx as a way to get interactive visualizations working quickly. I am working from the 0.17.2 stable release, and found there were a couple of very minor things which didn't compile. I made a Nim version branch, under the assumption that the use of getFloat on JsonNode in serializers might have been intentional, but it appears the equivalent available from my environment is getFNum. I also do not have a rand function.