### PR TITLE
allow using sdl2 from homebrew if present

### DIFF
--- a/nimx/naketools.nim
+++ b/nimx/naketools.nim
@@ -405,13 +405,6 @@ proc replaceVarsInFile(file: string, vars: Table[string, string]) =
         content = content.replace("$(" & k & ")", v)
     writeFile(file, content)
 
-proc chomp(s: string): string =
-    ## see https://dlang.org/library/std/string/chomp.html
-    if s.endsWith "\n":
-        result = s[0 ..< ^1]
-    else:
-        result = s
-
 proc buildSDLForDesktop(b: Builder): string =
     when defined(linux):
         result = "/usr/lib"
@@ -425,8 +418,9 @@ proc buildSDLForDesktop(b: Builder): string =
             # user has homebrew
             let ret = "brew --prefix sdl2".execCmdEx()
             if ret.exitCode == 0:
-                result = ret.output.string.chomp / "lib"
-                echo (result,)
+                result = ret.output.string
+                stripLineEnd(result)
+                result = result / "lib"
                 doAssert isValid(result), result
                 return result
             else:


### PR DESCRIPTION
* fixes `error: 'Xcode/SDL/SDL.xcodeproj' does not exist` for users that don't want to manually install SDL2 via xcode and instead use homebrew for that (references https://github.com/yglukhov/nimx/issues/320)

it's much simpler to install packages via homebrew on OSX nowdays; this allows using a homebrew installed version of sdl2, 

## note
it's not hardcoding brew location to /usr/local/ (not always installed there); it just checks for `brew` in PATH
