### PR TITLE
Fix issue #342 where SDL failed to link to some libraries

### DIFF
--- a/nimx/linkage_details.nim
+++ b/nimx/linkage_details.nim
@@ -128,7 +128,7 @@ when not defined(emscripten):
                 result.add parseStmt("passToCAndL(\"-framework " & n[i].strVal & "\")")
 
     when defined(ios):
-        useFrameworks("OpenGLES", "UIKit", "GameController", "CoreMotion")
+        useFrameworks("OpenGLES", "UIKit", "GameController", "CoreMotion", "Metal", "AVFoundation")
         when not defined(simulator):
             when hostCPU == "arm":
                 {.passC:"-arch armv7".}


### PR DESCRIPTION
Fix #342 by including the Metal and AVFoundation frameworks.  I don't know if this change breaks things for older versions of Xcode or the SDK.  I'm a completely inexperienced mobile developer.