### PR TITLE
fix x11 import

### DIFF
--- a/nimx/pasteboard/pasteboard_x11.nim
+++ b/nimx/pasteboard/pasteboard_x11.nim
@@ -2,7 +2,7 @@ import abstract_pasteboard
 export abstract_pasteboard
 import pasteboard_item
 import os, times
-import xlib, x, xatom, xutil
+import x11 / [xlib, x, xatom, xutil]
 import nimx/app, nimx/private/windows/sdl_window
 import sdl2
 


### PR DESCRIPTION
Once https://github.com/nim-lang/x11/pull/19 is merged, this will fix the error `nimx/pasteboard/pasteboard_x11.nim(5, 8) Error: cannot open file: xlib` which is raised when running `nim c --threads:on test/main.nim` is run.