### PR TITLE
small fix

### DIFF
--- a/nimx/composition.nim
+++ b/nimx/composition.nim
@@ -244,7 +244,7 @@ proc sdEllipseInRect*(pos: Vec2, rect: Vec4): float32 =
     let center = rect.xy + ab
     let p = pos - center
     result = dot(p * p, 1.0 / (ab * ab)) - 1.0
-    result *= min(ab.x, ab.y)
+    result *= nimsl.min(ab.x, ab.y)
 
 proc insetRect*(r: Vec4, by: float32): Vec4 = newVec4(r.xy + by, r.zw - by * 2.0)
 

--- a/nimx/context.nim
+++ b/nimx/context.nim
@@ -493,8 +493,8 @@ void compose() {
 """
 
 proc drawLine*(c: GraphicsContext, pointFrom: Point, pointTo: Point) =
-    let xfrom = min(pointFrom.x, pointTo.x)
-    let yfrom = min(pointFrom.y, pointTo.y)
+    let xfrom = nimsl.min(pointFrom.x, pointTo.x)
+    let yfrom = nimsl.min(pointFrom.y, pointTo.y)
     let xsize = max(pointFrom.x, pointTo.x) - xfrom
     let ysize = max(pointFrom.y, pointTo.y) - yfrom
     let r = newRect(xfrom - c.strokeWidth, yfrom - c.strokeWidth, xsize + 2 * c.strokeWidth, ysize + 2 * c.strokeWidth)


### PR DESCRIPTION
I recently added a proper overload of min/max of float32 to system.nim. This symbol does now clash with the definition of `min` in nimsl. For some reason `max` in nimsl is commented out and no symbol clash happens.