### PR TITLE
Fix off-by-one when finding table rows

### DIFF
--- a/nimx/table_view.nim
+++ b/nimx/table_view.nim
@@ -93,7 +93,7 @@ proc getRowsAtHeights(v: TableView, heights: openarray[Coord], rows: var openarr
         var j = 0
         rows[j] = -1
         for i in startRow ..< rowsCount:
-            if j > heights.len:
+            if j >= heights.len:
                 break
             height += v.heightOfRowUsingDelegate(i)
             if heights[j] < height:


### PR DESCRIPTION
One liner to fix crash when display table where height of row is fixed. See stack trace at bottom. To recreate with samples, add the patch below:

```
diff --git a/test/main.nim b/test/main.nim
index c76e9c5..97b49ee 100755
--- a/test/main.nim
+++ b/test/main.nim
@@ -60,6 +60,8 @@ proc startApplication() =
             nv.resizingMask = "wh"
             splitView.replaceSubview(currentView, nv)
             currentView = nv
+    tableView.heightOfRow = proc (row: int): Coord =
+      result = 20
 
     tableView.reloadData()
     tableView.selectRow(0)
```

When samples displays, the table of samples is compressed vertically, eliminating most of the whitespace. Then try resizing the top-level window up so that items in the table are no longer visible. This action should trigger the crash.

I only vaguely understand the code, but the fix seems simple enough.

Stack trace:
```
/home/kbee/dev/nimx/repo/test/main.nim(94) main
/home/kbee/dev/nimx/repo/nimx/private/windows/sdl_window.nim(550) runUntilQuit
/home/kbee/dev/nimx/repo/nimx/private/windows/sdl_window.nim(496) nextEvent
/home/kbee/dev/nimx/repo/nimx/private/windows/sdl_window.nim(435) handleEvent
/home/kbee/dev/nimx/repo/nimx/app.nim(91) handleEvent
/home/kbee/dev/nimx/repo/nimx/window_event_handling.nim(64) handleEvent
/home/kbee/dev/nimx/repo/nimx/window_event_handling.nim(78) handleEvent
/home/kbee/dev/nimx/repo/nimx/abstract_window.nim(79) drawWindow
/home/kbee/dev/nimx/repo/nimx/private/windows/sdl_window.nim(281) drawWindow
/home/kbee/dev/nimx/repo/nimx/abstract_window.nim(85) drawWindow
/home/kbee/dev/nimx/repo/nimx/view.nim(419) recursiveDrawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(414) drawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(402) drawWithinSuperview
/home/kbee/dev/nimx/repo/nimx/view.nim(419) recursiveDrawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(414) drawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(402) drawWithinSuperview
/home/kbee/dev/nimx/repo/nimx/view.nim(419) recursiveDrawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(414) drawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(400) drawWithinSuperview
/home/kbee/dev/nimx/repo/nimx/view.nim(419) recursiveDrawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(414) drawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(402) drawWithinSuperview
/home/kbee/dev/nimx/repo/nimx/view.nim(418) recursiveDrawSubviews
/home/kbee/dev/nimx/repo/nimx/view.nim(404) draw
/home/kbee/dev/nimx/repo/nimx/table_view.nim(317) draw
/home/kbee/dev/nimx/repo/nimx/table_view.nim(254) updateCellsInVisibleRect
/home/kbee/dev/nimx/repo/nimx/table_view.nim(99) getRowsAtHeights
/home/kbee/.choosenim/toolchains/nim-1.2.6/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: index 2 not in 0 .. 1 [IndexError]
Error: execution of an external program failed: '/home/kbee/dev/nimx/repo/build/linux/NimxApp '
```