### PR TITLE
prevent ios arithmetic error on init

### DIFF
--- a/nimx/private/windows/sdl_window.nim
+++ b/nimx/private/windows/sdl_window.nim
@@ -107,7 +107,7 @@ method animationStateChanged*(w: SdlWindow, state: bool) =
                 let w = cast[SdlWindow](p)
                 w.runAnimations()
                 w.drawWindow()
-            discard iPhoneSetAnimationCallback(w.impl, 0, animationCallback, cast[pointer](w))
+            discard iPhoneSetAnimationCallback(w.impl, 1, animationCallback, cast[pointer](w))
         else:
             discard iPhoneSetAnimationCallback(w.impl, 0, nil, nil)
 


### PR DESCRIPTION
Ios Simulator app crashed with ArithmeticError (my speculation: division by zero) on start on High Sierra #449 but explicitly specifying drawn frames fixes the problem.