### PR TITLE
Refresh of checkbox/radiobox button state

### DIFF
--- a/nimx/button.nim
+++ b/nimx/button.nim
@@ -285,9 +285,9 @@ proc handleToggleTouchEv(b: Button, e: var Event): bool =
     of bsUp:
         if e.localPosition.inRect(b.bounds):
             b.value = toggleValue(b.value)
+            b.setNeedsDisplay()   
             b.sendAction(e)
-        b.setState(if b.value == 1: bsDown else: bsUp)
-        b.setNeedsDisplay()        
+        b.setState(if b.value == 1: bsDown else: bsUp)     
     result = true
 
 method onTouchEv*(b: Button, e: var Event): bool =

--- a/nimx/button.nim
+++ b/nimx/button.nim
@@ -287,6 +287,7 @@ proc handleToggleTouchEv(b: Button, e: var Event): bool =
             b.value = toggleValue(b.value)
             b.sendAction(e)
         b.setState(if b.value == 1: bsDown else: bsUp)
+        b.setNeedsDisplay()        
     result = true
 
 method onTouchEv*(b: Button, e: var Event): bool =


### PR DESCRIPTION
Issue: For win based implementations, button state for checkbox/radiobox gets out of sync if user clicks first on a parent view then clicks on the button (clicking does not change the checkbox).  Moving the window causes the button to be redrawn.