### PR TITLE
button.nim - Clip the radiobox/checkbox text to match the button bounds

### DIFF
--- a/nimx/button.nim
+++ b/nimx/button.nim
@@ -95,11 +95,20 @@ proc drawTitle(b: Button, xOffset: Coord) =
             else:
                 blackColor()
 
-        let font = systemFont()
-        var titleRect = b.bounds
-        var pt = centerInRect(font.sizeOfString(b.title), titleRect)
+        # truncate title to bounds if required
+        var
+            titleRect = b.bounds
+            title = b.title
+        let 
+            font = systemFont()
+            sz = font.sizeOfString(title)
+        # reduce by size of checkbox/radiobox
+        titleRect.size.width -= titleRect.size.height
+        if sz.width > titleRect.size.width:
+            title.setLen(int(title.len.float * titleRect.size.width / sz.width))
+        var pt = centerInRect(sz, titleRect)
         if pt.x < xOffset: pt.x = xOffset
-        c.drawText(font, pt, b.title)
+        c.drawText(font, pt, title)
 
 var regularButtonComposition = newComposition """
 uniform vec4 uStrokeColor;


### PR DESCRIPTION
( **Only tested on win platform**)

Currently the text of a `radiobox` or `checkbox` can overflow the bounds of the button.  This means that clicking the text to the right of the button bound does not click the button.

This PR clips the text to match the width of the button bounds (which should be picked up by the developer and trigger them to adjust the sizing of the control).

Test code (there should be a gap of 10 between the two checkboxes where the user clicks neither checkboxes):

```
import nimx / [ view, button, window ]

runApplication:
    let w = newWindow(newRect(50, 50, 500, 150))
    let checkbox1 = newCheckbox(newRect(10, 20, 75, 16))
    #echo "Frame: " & $checkbox1.frame() & " bounds: " & $checkbox1.bounds()
    checkbox1.title = "Checkbox1"
    checkbox1.name = checkbox1.title
    w.addSubview(checkbox1)
    let checkbox2 = newCheckbox(newRect(95, 20, 75, 16))
    checkbox2.title = "Checkbox2"
    checkbox2.name = checkbox2.title
    w.addSubview(checkbox2)
```