### PR TITLE
haiku support

### DIFF
--- a/nimx/naketools.nim
+++ b/nimx/naketools.nim
@@ -396,6 +396,8 @@ proc checkSdlRoot(b: Builder) =
 proc buildSDLForDesktop(b: Builder): string =
     when defined(linux):
         result = "/usr/lib"
+    when defined(haiku):
+        result = "/system/develop/lib"
     elif defined(macosx):
         proc isValid(dir: string): bool =
             fileExists(dir / "libSDL2.a") or fileExists(dir / "libSDL2.dylib")

--- a/nimx/naketools.nim
+++ b/nimx/naketools.nim
@@ -275,6 +275,8 @@ proc newBuilder*(): Builder =
         newBuilder("macosx")
     elif defined(windows):
         newBuilder("windows")
+    elif defined(haiku):
+        newBuilder("haiku")
     else:
         newBuilder("linux")
 
@@ -396,8 +398,6 @@ proc checkSdlRoot(b: Builder) =
 proc buildSDLForDesktop(b: Builder): string =
     when defined(linux):
         result = "/usr/lib"
-    when defined(haiku):
-        result = "/system/develop/lib"
     elif defined(macosx):
         proc isValid(dir: string): bool =
             fileExists(dir / "libSDL2.a") or fileExists(dir / "libSDL2.dylib")
@@ -424,6 +424,8 @@ proc buildSDLForDesktop(b: Builder): string =
                 return result
 
         assert(false, "Don't know where to find SDL. Consider setting SDL_HOME environment variable.")
+    elif defined(haiku):
+        result = "/system/develop/lib"
     else:
         assert(false, "Don't know where to find SDL")
 

--- a/nimx/private/font/fontconfig.nim
+++ b/nimx/private/font/fontconfig.nim
@@ -18,6 +18,11 @@ elif defined(emscripten) or defined(wasm):
   [
     "res"
   ]
+elif defined(haiku):
+  [
+    "/system/data/fonts/otfonts",
+    "/system/data/fonts/ttfonts"
+  ]
 else:
   [
     "/usr/share/fonts/truetype",


### PR DESCRIPTION
hello, the following updates fix compilation (and allow running) on haiku:

* fixes library path for finding SDL library
* fixes font path search

tested on a recent version of haiku nightly (hrev56007)

below is a sample run of the example app compiling

```
> uname -a
Haiku shredder 1 hrev56007 Apr  9 2022 06:04:29 x86_64 x86_64 Haiku

> cat main.nim 
# File: main.nim
import nimx/window
import nimx/text_field

proc startApp() =
    # First create a window. Window is the root of view hierarchy.
    var wnd = newWindow(newRect(40, 40, 800, 600))

    # Create a static text field and add it to view hierarchy
    let label = newLabel(newRect(20, 20, 150, 20))
    label.text = "Hello, world!"
    wnd.addSubview(label)

# Run the app
runApplication:
    startApp()

> nim c  -r --threads:on main.nim 
Hint: used config file '/boot/system/lib/nim/config/nim.cfg' [Conf]
Hint: used config file '/boot/system/lib/nim/config/config.nims' [Conf]
...............................................................................................................................................................................
/boot/home/.nimble/pkgs/async_http_request-0.1.4/async_http_request.nim(157, 34) template/generic instantiation of `request` from here
/boot/system/lib/nim/lib/pure/httpclient.nim(1086, 14) Warning: Deprecated since v1.5; use HttpMethod enum instead; string parameter httpMethod is deprecated [User]
....................................................................
CC: stdlib_assertions.nim
CC: stdlib_dollars.nim
CC: stdlib_sharedlist.nim
CC: stdlib_io.nim
CC: stdlib_system.nim
CC: stdlib_tables.nim
CC: stdlib_parseutils.nim
CC: stdlib_strutils.nim
CC: stdlib_dynlib.nim
CC: ../../../../.nimble/pkgs/opengl-#head/opengl.nim
CC: stdlib_times.nim
CC: stdlib_pathnorm.nim
CC: stdlib_os.nim
CC: stdlib_logging.nim
CC: stdlib_streams.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/portable_gl.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/mini_profiler.nim
CC: ../../../../.nimble/pkgs/variant-0.2.12/variant.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/url_stream.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/asset_loading.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/abstract_asset_bundle.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/native_asset_bundle.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/asset_manager.nim
CC: stdlib_parsejson.nim
CC: stdlib_json.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/serializers.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/private/worker_queue.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/image.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/composition.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/timer.nim
CC: ../../../../.nimble/pkgs/rect_packer-0.1.0/rect_packer.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/private/font/stb_ttf_glyph_provider.nim
CC: ../../../../.nimble/pkgs/ttf-0.2.12/ttf/edtaa3func.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/font.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/private/text_drawing.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/context.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/animation.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/animation_runner.nim
CC: ../../../../.nimble/pkgs/kiwi-0.1.0/kiwi/variable.nim
CC: ../../../../.nimble/pkgs/kiwi-0.1.0/kiwi/expression.nim
CC: ../../../../.nimble/pkgs/kiwi-0.1.0/kiwi/constraint.nim
CC: ../../../../.nimble/pkgs/kiwi-0.1.0/kiwi/symbolics.nim
CC: ../../../../.nimble/pkgs/kiwi-0.1.0/kiwi/solver.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/class_registry.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/notification_center.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/view.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/drag_and_drop.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/abstract_window.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/view_event_handling.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/window_event_handling.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/app.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/private/windows/sdl_window.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/control.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/unistring.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/formatted_text.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/slider.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/assets/json_loading.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/ui_resource.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/scroll_view.nim
CC: ../../../../.nimble/pkgs/nimx-0.1/nimx/text_field.nim
Hint:  [Link]
Hint: gc: refc; threads: on; opt: none (DEBUG BUILD, `-d:release` generates faster code)
130734 lines; 11.111s; 280.949MiB peakmem; proj: /boot/home/src/git/nim-libs/nimx-sample/main.nim; out: /boot/home/src/git/nim-libs/nimx-sample/main [SuccessX]
Hint: /boot/home/src/git/nim-libs/nimx-sample/main  [Exec]
OpenGL load add-on: /boot/system/add-ons/opengl/Software Pipe
OpenGL add-on registered: /boot/system/add-ons/opengl/Software Pipe
GalliumContext: CreateDisplay: Using llvmpipe (LLVM 9.0.1, 256 bits) driver.
```