### PR TITLE
allow variant version >= 0.3

### DIFF
--- a/nimx.nimble
+++ b/nimx.nimble
@@ -18,7 +18,7 @@ requires "jnim" # For android target
 requires "nake"
 requires "closure_compiler >= 0.3.1"
 requires "plists"
-requires "variant >= 0.2 & < 0.3"
+requires "variant >= 0.2"
 requires "kiwi"
 requires "https://github.com/yglukhov/ttf >= 0.2.9 & < 0.3"
 requires "https://github.com/yglukhov/async_http_request"


### PR DESCRIPTION
[variant](https://github.com/yglukhov/variant) is currently on version 0.3 since August 2023, but this line restricting the variant version to below 0.3 has been there since [2016](https://github.com/yglukhov/nimx/commit/3ea539e4fcf98d2bf0e8a98abc05915b8bb30553), so maybe this is unintentional.