### PR TITLE
Add font path for Fedora

### DIFF
--- a/nimx/private/font/fontconfig.nim
+++ b/nimx/private/font/fontconfig.nim
@@ -30,7 +30,8 @@ else:
     "/usr/share/fonts/TTF",
     "/usr/share/fonts/truetype/dejavu",
     "/usr/share/fonts/dejavu",
-    "/usr/share/fonts"
+    "/usr/share/fonts",
+    "/usr/share/fonts/dejavu-sans-fonts/"
   ]
 
 iterator potentialFontFilesForFace*(face: string): string =


### PR DESCRIPTION
This makes the hello world example run on Fedora, fixes #485